### PR TITLE
feat: rename app display name to Better You

### DIFF
--- a/HabitStack/Info.plist
+++ b/HabitStack/Info.plist
@@ -10,6 +10,8 @@
 	<string>com.tomerab.habitstack</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>Better You</string>
 	<key>CFBundleName</key>
 	<string>HabitStack</string>
 	<key>CFBundlePackageType</key>

--- a/HabitStackWidget/Info.plist
+++ b/HabitStackWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>HabitStack Widget</string>
+	<string>Better You Widget</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Summary

- Adds `CFBundleDisplayName = "Better You"` to `HabitStack/Info.plist` (previously missing — only `CFBundleName` was set)
- Updates `HabitStackWidget/Info.plist` `CFBundleDisplayName` from `"HabitStack Widget"` to `"Better You Widget"`

Closes #6

## Test plan

- [ ] Build and run in Xcode simulator — confirm home screen icon label shows "Better You"
- [ ] Confirm widget gallery entry shows "Better You Widget"

⚠️ Untested — requires manual Xcode build verification