### PR TITLE
feat: rename 'Habits Scorecard' to 'Daily Review'

### DIFF
--- a/HabitStack/Views/FourLaws/FourLawsView.swift
+++ b/HabitStack/Views/FourLaws/FourLawsView.swift
@@ -32,7 +32,7 @@ struct FourLawsView: View {
                                     .foregroundStyle(Color("Teal"))
                             }
                             VStack(alignment: .leading, spacing: 3) {
-                                Text("Habits Scorecard")
+                                Text("Daily Review")
                                     .font(.subheadline.bold())
                                     .foregroundStyle(Color("Stone950"))
                                 Text("List your daily behaviors and rate them +/=/–. Make the unconscious conscious.")

--- a/HabitStack/Views/FourLaws/FourLawsView.swift
+++ b/HabitStack/Views/FourLaws/FourLawsView.swift
@@ -20,7 +20,7 @@ struct FourLawsView: View {
                     )
                     .padding(.horizontal, 16)
 
-                    // MARK: 2. Habits Scorecard — prominent action
+                    // MARK: 2. Daily Review — prominent action
                     Button { showScorecard = true } label: {
                         HStack(spacing: 16) {
                             ZStack {

--- a/HabitStack/Views/FourLaws/HabitsScorecardView.swift
+++ b/HabitStack/Views/FourLaws/HabitsScorecardView.swift
@@ -138,7 +138,7 @@ struct HabitsScorecardView: View {
                 .padding(.vertical, 12)
             }
             .background(Color("AppBackground").ignoresSafeArea())
-            .navigationTitle("Habits Scorecard")
+            .navigationTitle("Daily Review")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 if let onContinue {


### PR DESCRIPTION
## Summary
- Renames the 'Habits Scorecard' navigation title in `HabitsScorecardView` to **'Daily Review'**
- Renames the 'Habits Scorecard' button label in `FourLawsView` to **'Daily Review'**

Closes #11.

## Changes
| File | Change |
|------|--------|
| `HabitStack/Views/FourLaws/HabitsScorecardView.swift` | `.navigationTitle` string |
| `HabitStack/Views/FourLaws/FourLawsView.swift` | Button label `Text(...)` |

> Code identifiers (`HabitsScorecardView`, `ScorecardEntry`, etc.) were intentionally left unchanged — only user-visible display strings were updated.

## Test plan
- [ ] Build and run in Xcode simulator
- [ ] Verify "Daily Review" title appears in the sheet opened from FourLawsView
- [ ] Verify "Daily Review" navigation title appears inside the scorecard sheet
- [ ] Verify onboarding flow still shows the view correctly

⚠️ Untested - requires manual Xcode build verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)