### PR TITLE
feat: update app name references from 'Habit Stack' to 'Better You'

### DIFF
--- a/HabitStack/Views/Auth/AuthView.swift
+++ b/HabitStack/Views/Auth/AuthView.swift
@@ -14,7 +14,7 @@ struct AuthView: View {
                 Spacer()
 
                 VStack(spacing: 8) {
-                    Text("HabitStack")
+                    Text("Better You")
                         .font(.largeTitle.bold())
                         .foregroundStyle(Color("Teal"))
                     Text("Build better habits, one day at a time.")

--- a/HabitStack/Views/Onboarding/WelcomeView.swift
+++ b/HabitStack/Views/Onboarding/WelcomeView.swift
@@ -8,7 +8,7 @@ struct WelcomeView: View {
             Spacer()
 
             VStack(spacing: 16) {
-                Text("HabitStack")
+                Text("Better You")
                     .font(.system(size: 48, weight: .bold, design: .rounded))
                     .foregroundStyle(Color("Teal"))
 

--- a/HabitStack/Views/Today/StreakShareCard.swift
+++ b/HabitStack/Views/Today/StreakShareCard.swift
@@ -54,7 +54,7 @@ struct StreakShareCard: View {
                     Image(systemName: "checkmark.seal.fill")
                         .font(.caption)
                         .foregroundStyle(Color(hex: "#0D9488"))
-                    Text("HabitStack")
+                    Text("Better You")
                         .font(.caption.bold())
                         .foregroundStyle(Color(hex: "#94a3b8"))
                 }


### PR DESCRIPTION
## Summary

- Replaces `Text("HabitStack")` with `Text("Better You")` in `WelcomeView.swift`, `AuthView.swift`, and `StreakShareCard.swift`
- `Info.plist` `CFBundleDisplayName` was already set to "Better You" — no change needed there
- Code identifiers (struct names, file names, bundle name) left unchanged to avoid Xcode project breakage

Closes #15

## Test plan

- [ ] Build in Xcode and verify app launches correctly
- [ ] Check WelcomeView (onboarding) shows "Better You" as the app name
- [ ] Check AuthView (sign-in screen) shows "Better You" as the app name
- [ ] Check StreakShareCard watermark shows "Better You"

⚠️ Untested - requires manual Xcode build verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)